### PR TITLE
Fixed query action in new version of stackstorm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.2.0
+
+* Fixed internal working of the query action compatible with sqlalchemy 2.0+
+* Replaced row_to_dict tuple keys loop with sqlalchemy todict function
+
 ## 1.1.1
 
 * Resolve issue where query is sometimes missing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.2.0
+## 1.1.2
 
 * Fixed internal working of the query action compatible with sqlalchemy 2.0+
 * Replaced row_to_dict tuple keys loop with sqlalchemy todict function

--- a/actions/generic_query.py
+++ b/actions/generic_query.py
@@ -34,6 +34,6 @@ class SQLQueryAction(BaseAction):
 
             return return_result
 
-        # If The with is broken or crashes for some reason 
+        # If The with is broken or crashes for some reason
         # we return an False (error) with None as the data
         return (False, None)

--- a/actions/generic_query.py
+++ b/actions/generic_query.py
@@ -34,5 +34,6 @@ class SQLQueryAction(BaseAction):
 
             return return_result
 
-        # If The with is broken or crashes for some reason we return an False (error) with None as the data
+        # If The with is broken or crashes for some reason 
+        # we return an False (error) with None as the data
         return (False, None)

--- a/actions/generic_query.py
+++ b/actions/generic_query.py
@@ -18,10 +18,9 @@ class SQLQueryAction(BaseAction):
 
         query = self.get_del_arg('query', kwargs_dict)
 
-        return_result = None
         with self.db_connection(kwargs_dict) as conn:
             # Execute the query
-            query_result = conn.execute(query)
+            query_result = conn.exec_driver_sql(query)
 
             # We need to execute these commands while connection is still open.
             return_result = {'affected_rows': query_result.rowcount}
@@ -33,4 +32,7 @@ class SQLQueryAction(BaseAction):
                     # Convert that to a dictionary for return
                     return_result.append(self.row_to_dict(row))
 
-        return return_result
+            return return_result
+
+        # If The with is broken or crashes for some reason we return an False (error) with None as the data
+        return (False, None)

--- a/actions/lib/base_action.py
+++ b/actions/lib/base_action.py
@@ -61,7 +61,7 @@ class BaseAction(Action):
         returns: dictionary of values
         """
         return_dict = {}
-        for column in row.keys():
+        for column in row._asdict().keys():
             value = getattr(row, column)
 
             if isinstance(value, datetime.date):
@@ -120,8 +120,12 @@ class BaseAction(Action):
             connection['drivername'] = default_driver
 
         # Check if query is in de connection
+        # We use a immutabledict as required by the documentation of sqlalchemy instead of a tuple.
+        # Because sqlalchemy made for this funtions its own 'datatype' that it knows how to handle.
+        # Aimes to be compatible with tuple but not fully.
+        # https://www.programcreek.com/python/example/58798/sqlalchemy.util.immutabledict
         if 'query' not in connection:
-            connection['query'] = ()
+            connection['query'] = sqlalchemy.util.immutabledict()
 
         # Format the connection string
         database_connection_string = URL(**connection)

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - Postgres
   - MySQL
   - MsSQL
-version: 1.2.0
+version: 1.1.2
 author: Encore Technologies
 email: code@encore.tech
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - Postgres
   - MySQL
   - MsSQL
-version: 1.1.1
+version: 1.2.0
 author: Encore Technologies
 email: code@encore.tech
 python_versions:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
 mock>=1.3.0,<2.0
 unittest2>=1.1.0,<2.0
 nose>=1.3.7
-sqlalchemy
+sqlalchemy~=2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sqlalchemy
+sqlalchemy~=2.0.3
 psycopg2 <=2.8
 pymysql
 pymssql<3.0

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -16,6 +16,9 @@ __all__ = [
 
 
 class TestObjectDB():
+    def __init__(self):
+        self.test1 = 'value'
+        self.test2 = 'value2'
     def _asdict(self):
         return {'test1': 'value', 'test2': 'value2'}
 

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -41,6 +41,7 @@ class TestObjectDBNum():
                 'testdict': {'test': 'value'},
                 'testdatetime': datetime.datetime(2019, 1, 1, 0, 0)}
 
+
 class TestActionLibBaseAction(SqlBaseActionTestCase):
     __test__ = True
     action_cls = SQLInsertAction

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -19,6 +19,7 @@ class TestObjectDB():
     def __init__(self):
         self.test1 = 'value'
         self.test2 = 'value2'
+
     def _asdict(self):
         return {'test1': 'value', 'test2': 'value2'}
 

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -24,6 +24,23 @@ class TestObjectDB():
         return {'test1': 'value', 'test2': 'value2'}
 
 
+class TestObjectDBNum():
+    def __init__(self):
+        self.teststring = 'value'
+        self.testinteger = 1
+        self.testdecimal=decimal.Decimal('5.543')
+        self.testfloat=2.352
+        self.testdict={'test': 'value'}
+        self.testdatetime=datetime.datetime(2019, 1, 1, 0, 0)
+
+    def _asdict(self):
+        return {'teststring': 'value',
+                'testdecimal': decimal.Decimal('5.543'),
+                'testfloat': 2.352,
+                'testdict': {'test': 'value'},
+                'testdatetime': datetime.datetime(2019, 1, 1, 0, 0)}
+
+
 class TestActionLibBaseAction(SqlBaseActionTestCase):
     __test__ = True
     action_cls = SQLInsertAction
@@ -115,18 +132,7 @@ class TestActionLibBaseAction(SqlBaseActionTestCase):
 
     def test_row_to_dict_unit_convert(self):
         action = self.get_action_instance({})
-        test_row = mock.Mock(teststring='value',
-                            testinteger=1,
-                            testdecimal=decimal.Decimal('5.543'),
-                            testfloat=2.352,
-                            testdict={'test': 'value'},
-                            testdatetime=datetime.datetime(2019, 1, 1, 0, 0))
-        test_row.keys.return_value = ['teststring',
-                                    'testinteger',
-                                    'testdecimal',
-                                    'testfloat',
-                                    'testdict',
-                                    'testdatetime']
+        test_row = TestObjectDBNum()
         expected_result = {
             'testinteger': 1,
             'testdict': {'test': 'value'},

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -14,6 +14,10 @@ __all__ = [
     'TestActionLibBaseAction'
 ]
 
+class TestObjectDB():
+  def _asdict(self):
+    return {'test1': 'value', 'test2': 'value2'}
+
 
 class TestActionLibBaseAction(SqlBaseActionTestCase):
     __test__ = True
@@ -96,9 +100,7 @@ class TestActionLibBaseAction(SqlBaseActionTestCase):
 
     def test_row_to_dict(self):
         action = self.get_action_instance({})
-        test_row = mock.Mock({'test1': 'value', 'test2': 'value2'})
-        test_row._asdict = {'test1': 'value', 'test2': 'value2'}
-        test_row.keys.return_value = ['test1', 'test2']
+        test_row = TestObjectDB()
         expected_result = {
             'test1': 'value',
             'test2': 'value2'

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -14,9 +14,10 @@ __all__ = [
     'TestActionLibBaseAction'
 ]
 
+
 class TestObjectDB():
-  def _asdict(self):
-    return {'test1': 'value', 'test2': 'value2'}
+    def _asdict(self):
+        return {'test1': 'value', 'test2': 'value2'}
 
 
 class TestActionLibBaseAction(SqlBaseActionTestCase):

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -96,7 +96,7 @@ class TestActionLibBaseAction(SqlBaseActionTestCase):
 
     def test_row_to_dict(self):
         action = self.get_action_instance({})
-        test_row = mock.Mock({'test1':'value','test2':'value2'})
+        test_row = mock.Mock({'test1': 'value', 'test2': 'value2'})
         test_row.keys.return_value = ['test1', 'test2']
         expected_result = {
             'test1': 'value',

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -97,6 +97,7 @@ class TestActionLibBaseAction(SqlBaseActionTestCase):
     def test_row_to_dict(self):
         action = self.get_action_instance({})
         test_row = mock.Mock({'test1': 'value', 'test2': 'value2'})
+        test_row._asdict = {'test1': 'value', 'test2': 'value2'}
         test_row.keys.return_value = ['test1', 'test2']
         expected_result = {
             'test1': 'value',

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -28,10 +28,10 @@ class TestObjectDBNum():
     def __init__(self):
         self.teststring = 'value'
         self.testinteger = 1
-        self.testdecimal=decimal.Decimal('5.543')
-        self.testfloat=2.352
-        self.testdict={'test': 'value'}
-        self.testdatetime=datetime.datetime(2019, 1, 1, 0, 0)
+        self.testdecimal = decimal.Decimal('5.543')
+        self.testfloat = 2.352
+        self.testdict = {'test': 'value'}
+        self.testdatetime = datetime.datetime(2019, 1, 1, 0, 0)
 
     def _asdict(self):
         return {'teststring': 'value',

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -96,7 +96,7 @@ class TestActionLibBaseAction(SqlBaseActionTestCase):
 
     def test_row_to_dict(self):
         action = self.get_action_instance({})
-        test_row = mock.Mock(test1='value', test2='value2')
+        test_row = mock.Mock({'test1':'value','test2':'value2'})
         test_row.keys.return_value = ['test1', 'test2']
         expected_result = {
             'test1': 'value',

--- a/tests/test_action_lib_base_action.py
+++ b/tests/test_action_lib_base_action.py
@@ -35,11 +35,11 @@ class TestObjectDBNum():
 
     def _asdict(self):
         return {'teststring': 'value',
+                'testinteger': 1,
                 'testdecimal': decimal.Decimal('5.543'),
                 'testfloat': 2.352,
                 'testdict': {'test': 'value'},
                 'testdatetime': datetime.datetime(2019, 1, 1, 0, 0)}
-
 
 class TestActionLibBaseAction(SqlBaseActionTestCase):
     __test__ = True

--- a/tests/test_action_query.py
+++ b/tests/test_action_query.py
@@ -47,7 +47,7 @@ class TestActionSQLQueryAction(SqlBaseActionTestCase):
         mock_query_results = mock.Mock(returns_rows=True, rowcount=1)
         mock_query_results.fetchall.return_value = [test_row]
         mock_connection = mock.Mock()
-        mock_connection.execute.return_value = mock_query_results
+        mock_connection.exec_driver_sql.return_value = mock_query_results
         mock_connection.close.return_value = "Successfully disconnected"
         mock_connect_to_db.return_value.__enter__.return_value = mock_connection
 
@@ -56,7 +56,7 @@ class TestActionSQLQueryAction(SqlBaseActionTestCase):
         result = action.run(**test_dict)
         self.assertEqual(result, expected_result)
         mock_connect_to_db.assert_called_once_with(test_dict)
-        mock_connection.execute.assert_called_once_with(test_dict['query'])
+        mock_connection.exec_driver_sql.assert_called_once_with(test_dict['query'])
 
     @mock.patch('lib.base_action.BaseAction.db_connection')
     def test_run_connction(self, mock_connect_to_db):
@@ -78,4 +78,4 @@ class TestActionSQLQueryAction(SqlBaseActionTestCase):
         result = action.run(**test_dict)
         self.assertEqual(result, expected_result)
         mock_connect_to_db.assert_called_once_with(test_dict)
-        mock_connection.execute.assert_called_once_with(test_dict['query'])
+        mock_connection.exec_driver_sql.assert_called_once_with(test_dict['query'])

--- a/tests/test_action_query.py
+++ b/tests/test_action_query.py
@@ -11,6 +11,15 @@ __all__ = [
 ]
 
 
+class TestObjectDB():
+    def __init__(self):
+        self.test1 = 'value'
+        self.test2 = 'value2'
+
+    def _asdict(self):
+        return {'test1': 'value', 'test2': 'value2'}
+
+
 class TestActionSQLQueryAction(SqlBaseActionTestCase):
     __test__ = True
     action_cls = SQLQueryAction
@@ -30,8 +39,7 @@ class TestActionSQLQueryAction(SqlBaseActionTestCase):
             'query': 'generic query'
         }
         test_dict.update(connection_config)
-        test_row = mock.Mock(test1='value', test2='value2')
-        test_row.keys.return_value = ['test1', 'test2']
+        test_row = TestObjectDB()
         expected_result = [{
             'test1': 'value',
             'test2': 'value2'
@@ -61,7 +69,7 @@ class TestActionSQLQueryAction(SqlBaseActionTestCase):
         expected_result = {'affected_rows': 5}
         mock_query_results = mock.Mock(returns_rows=False, rowcount=5)
         mock_connection = mock.Mock()
-        mock_connection.execute.return_value = mock_query_results
+        mock_connection.exec_driver_sql.return_value = mock_query_results
         mock_connection.close.return_value = "Successfully disconnected"
         mock_connect_to_db.return_value.__enter__.return_value = mock_connection
 


### PR DESCRIPTION
After the update to 3.8.0 we notices that our more advanced sql.query's where not working anymore.
We found that after version 2.0 of SQLAlchemy the method for passing string queries using the `conn.execute(query)` was  removed (https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execute):

> Changed in version 2.0: The [Connection.execution_options()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options) method, in contrast to other objects with this method, modifies the connection in-place without creating copy of it.

So we implemented the exec_driver_sql function which does support passing queries in string format.
We also noticed that the deriving the keys from a tuple was not stable for our queries. So we implemented the internal `_asdict()` function into the loop to auto-convert the tuples to a parsable dict-type.