### PR TITLE
Modification in the descriptions and actions along with tests.

### DIFF
--- a/actions/delete.py
+++ b/actions/delete.py
@@ -19,11 +19,13 @@ class SQLDeleteAction(BaseAction):
 
         where_dict = self.get_del_arg('where', kwargs_dict)
         table = self.get_del_arg('table', kwargs_dict)
+        schema = self.get_del_arg('schema', kwargs_dict)
 
         with self.db_connection(kwargs_dict) as conn:
             # Get the SQL table
             sql_table = sqlalchemy.Table(table,
                                         self.meta,
+                                        schema=schema,
                                         autoload=True,
                                         autoload_with=self.engine)
 

--- a/actions/delete.yaml
+++ b/actions/delete.yaml
@@ -44,10 +44,14 @@
       description: >
         Dictionary of data to be used to create a WHERE clause for the DELETE statement
         {
-          'column_1': 'data_to_match_1',
-          'column_2': 'data_to_match_2',
-          'column_3': 'data_to_match_3',
-          'column_4': 'data_to_match_4',
+          "column_1": "data_to_match_1",
+          "column_2": "data_to_match_2",
+          "column_3": "data_to_match_3",
+          "column_4": "data_to_match_4",
         }
       required: false
       default: {}
+    schema:
+      type: string
+      description: "Database schema under which the table is created."
+      required: false

--- a/actions/insert.py
+++ b/actions/insert.py
@@ -19,6 +19,7 @@ class SQLInsertAction(BaseAction):
 
         insert_data = self.get_del_arg('data', kwargs_dict)
         insert_table = self.get_del_arg('table', kwargs_dict)
+        insert_schema = self.get_del_arg('schema', kwargs_dict)
 
         if not isinstance(insert_data, list):
             insert_data = [insert_data]
@@ -28,10 +29,11 @@ class SQLInsertAction(BaseAction):
             sql_table = sqlalchemy.Table(insert_table,
                                         self.meta,
                                         autoload=True,
+                                        schema=insert_schema,
                                         autoload_with=self.engine)
 
             # Execute the insert query
-            conn.execute(sql_table.insert(),  # pylint: disable-msg=no-value-for-parameter
+            conn.execute(sql_table.insert(inline=True),
                         insert_data)
 
         return True

--- a/actions/insert.yaml
+++ b/actions/insert.yaml
@@ -44,9 +44,13 @@
       description: >
         Dictionary of data to be inserted where the key corresponds to the column of the table
         {
-          'column_1': 'data_to_insert_1',
-          'column_2': 'data_to_insert_2',
-          'column_3': 'data_to_insert_3',
-          'column_4': 'data_to_insert_4',
+          "column_1": "data_to_insert_1",
+          "column_2": "data_to_insert_2",
+          "column_3": "data_to_insert_3",
+          "column_4": "data_to_insert_4",
         }
       required: true
+    schema:
+      type: string
+      description: "Database schema under which the table is created."
+      required: false

--- a/actions/insert_bulk.yaml
+++ b/actions/insert_bulk.yaml
@@ -44,14 +44,14 @@
       description: >
         List of Dictionaries of data to be inserted where the key corresponds to the column of the table
         [{
-          'column_1': 'data_to_insert_1',
-          'column_2': 'data_to_insert_2',
-          'column_3': 'data_to_insert_3',
-          'column_4': 'data_to_insert_4',
+          "column_1": "data_to_insert_1",
+          "column_2": "data_to_insert_2",
+          "column_3": "data_to_insert_3",
+          "column_4": "data_to_insert_4",
         },{
-          'column_1': 'data_to_insert_1',
-          'column_2': 'data_to_insert_2',
-          'column_3': 'data_to_insert_3',
-          'column_4': 'data_to_insert_4',
+          "column_1": "data_to_insert_1",
+          "column_2": "data_to_insert_2",
+          "column_3": "data_to_insert_3",
+          "column_4": "data_to_insert_4",
         }]
       required: true

--- a/actions/update.py
+++ b/actions/update.py
@@ -20,11 +20,13 @@ class SQLUpdateAction(BaseAction):
         where_dict = self.get_del_arg('where', kwargs_dict)
         update_dict = self.get_del_arg('update', kwargs_dict)
         table = self.get_del_arg('table', kwargs_dict)
+        schema = self.get_del_arg('schema', kwargs_dict)
 
         with self.db_connection(kwargs_dict) as conn:
             # Get the SQL table
             sql_table = sqlalchemy.Table(table,
                                         self.meta,
+                                        schema=schema,
                                         autoload=True,
                                         autoload_with=self.engine)
 

--- a/actions/update.yaml
+++ b/actions/update.yaml
@@ -44,10 +44,10 @@
       description: >
         Dictionary of data to be used to create a WHERE clause for the UPDATE statement
         {
-          'column_1': 'data_to_match_1',
-          'column_2': 'data_to_match_2',
-          'column_3': 'data_to_match_3',
-          'column_4': 'data_to_match_4',
+          "column_1": "data_to_match_1",
+          "column_2": "data_to_match_2",
+          "column_3": "data_to_match_3",
+          "column_4": "data_to_match_4",
         }
       required: false
       default: {}
@@ -56,9 +56,13 @@
       description: >
         Dictionary of data to be used to as Values to update for the UPDATE statement
         {
-          'column_1': 'data_to_update_1',
-          'column_2': 'data_to_update_2',
-          'column_3': 'data_to_update_3',
-          'column_4': 'data_to_update_4',
+          "column_1": "data_to_update_1",
+          "column_2": "data_to_update_2",
+          "column_3": "data_to_update_3",
+          "column_4": "data_to_update_4",
         }
       required: true
+    schema:
+      type: string
+      description: "Database schema under which the table is created."
+      required: false

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -59,6 +59,7 @@ class TestActionSQLDeleteAction(SqlBaseActionTestCase):
         mock_connect_to_db.assert_called_once_with(test_dict)
         mock_sqlalchemy.Table.assert_called_once_with(test_dict['table'],
                                                       action_meta,
+                                                      schema=None,
                                                       autoload=True,
                                                       autoload_with=action_engine)
         mock_connection.execute.assert_called_once_with(mock_where_return, execute_dict)
@@ -94,6 +95,7 @@ class TestActionSQLDeleteAction(SqlBaseActionTestCase):
         mock_connect_to_db.assert_called_once_with(test_dict)
         mock_sqlalchemy.Table.assert_called_once_with(test_dict['table'],
                                                       action_meta,
+                                                      schema=None,
                                                       autoload=True,
                                                       autoload_with=action_engine)
         mock_connection.execute.assert_called_once_with(mock_delete_return, None)

--- a/tests/test_action_insert.py
+++ b/tests/test_action_insert.py
@@ -55,6 +55,7 @@ class TestActionSQLInsertAction(SqlBaseActionTestCase):
         mock_connect_to_db.assert_called_once_with(test_dict)
         mock_sqlalchemy.Table.assert_called_once_with(test_dict['table'],
                                                       action_meta,
+                                                      schema=None,
                                                       autoload=True,
                                                       autoload_with=action_engine)
         mock_connection.execute.assert_called_once_with(insert_return, [test_dict['data']])
@@ -95,6 +96,7 @@ class TestActionSQLInsertAction(SqlBaseActionTestCase):
         mock_connect_to_db.assert_called_once_with(test_dict)
         mock_sqlalchemy.Table.assert_called_once_with(test_dict['table'],
                                                       action_meta,
+                                                      schema=None,
                                                       autoload=True,
                                                       autoload_with=action_engine)
         mock_connection.execute.assert_called_once_with(insert_return, test_dict['data'])

--- a/tests/test_action_update.py
+++ b/tests/test_action_update.py
@@ -65,6 +65,7 @@ class TestActionSQLUpdateAction(SqlBaseActionTestCase):
         mock_connect_to_db.assert_called_once_with(test_dict)
         mock_sqlalchemy.Table.assert_called_once_with(test_dict['table'],
                                                       action_meta,
+                                                      schema=None,
                                                       autoload=True,
                                                       autoload_with=action_engine)
         mock_connection.execute.assert_called_once_with(mock_values_return, execute_dict)
@@ -106,6 +107,7 @@ class TestActionSQLUpdateAction(SqlBaseActionTestCase):
         mock_connect_to_db.assert_called_once_with(test_dict)
         mock_sqlalchemy.Table.assert_called_once_with(test_dict['table'],
                                                       action_meta,
+                                                      schema=None,
                                                       autoload=True,
                                                       autoload_with=action_engine)
         mock_connection.execute.assert_called_once_with(mock_values_return,


### PR DESCRIPTION
Updated the descriptions of all parameters in the pack that take a JSON input to use double-quotes. The descriptions currently give examples with single-quotes, which do not work in the ST2 UI.
Also, Insert, Update, and Delete actions in the SQL pack only search the 'dbo' schema. Added schema parameter to support different schemas in the actions and modified to accommodate triggers.
Also modified the tests to accommodate the schema change.