### PR TITLE
Pinned pymssql version to  <=2.3.0 for Python 3.8 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.2
+
+* Pinned pymssql version to <=2.3.2 for Python 3.8 compatibility 
+
 ## 1.1.1
 
 * Resolve issue where query is sometimes missing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2
 
-* Pinned pymssql version to <=2.3.2 for Python 3.8 compatibility 
+* Pinned pymssql version to <=2.3.0 for Python 3.8 compatibility 
 
 ## 1.1.1
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - Postgres
   - MySQL
   - MsSQL
-version: 1.1.1
+version: 1.1.2
 author: Encore Technologies
 email: code@encore.tech
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlalchemy
 psycopg2 <=2.8
 pymysql
-pymssql<3.0
+pymssql<=2.3.2
 cx_Oracle<=7.3.0
 fdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlalchemy
 psycopg2 <=2.8
 pymysql
-pymssql<=2.3.0
+pymssql<=2.3.1
 cx_Oracle<=7.3.0
 fdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlalchemy
 psycopg2 <=2.8
 pymysql
-pymssql<=2.3.1
+pymssql<=2.3.0
 cx_Oracle<=7.3.0
 fdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlalchemy
 psycopg2 <=2.8
 pymysql
-pymssql<=2.3.2
+pymssql<=2.3.0
 cx_Oracle<=7.3.0
 fdb


### PR DESCRIPTION
A recent issue has popped up for the SQL pack which makes it uninstallable.

Changes have been pushed to the `pymssql` Python library which makes it incompatible with ST2 which is still on 3.8. Attempting to install the pack will fail at installing requirements as it will detect that pymssql version `2.3.4` is available, which it will attempt to use as it satisfies the current `<3.0` set in `requirements.txt` despite it not being compatible with Python 3.8.

The last version which works is `2.3.0`. [Link to PyPi library for 2.3.3](https://pypi.org/project/pymssql/2.3.3/) showing Python 3.8 support has been removed. The current version of pymssql has actually already moved to 2.3.4.

Trying to install the pack as is throws some gcc/Cython errors. I tried investigating it some but the only thing I found that did work was cloning the repo and pinning the version to `2.3.0` in requirements.txt myself and installing from my pack.

Steps to reproduce:
1. Install `sql` exchange pack using either the UI or `st2 pack install sql` from the command line.

Changes made:

1. `requirements.txt` - changed `pymssql` version from `<3.0` to `<=2.3.0`